### PR TITLE
Updating Log4j version to 2.17.0 because of CVE-2021-45105 vulnerability.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,7 @@ def versions = [
         hibernate          : '5.6.0.Final',
         mapstruct          : '1.2.0.Final',
         springSecurity     : '5.5.2',
-        log4JVersion       : '2.16.0'
+        log4JVersion       : '2.17.0'
 ]
 
 sourceSets {


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Update Log4j version to 2.17.0
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105


**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```
