### PR TITLE
Update the response code when getting markUp by non-enxistent document ID to 404

### DIFF
--- a/src/aat/java/uk/gov/hmcts/reform/em/npa/functional/MarkUpScenarios.java
+++ b/src/aat/java/uk/gov/hmcts/reform/em/npa/functional/MarkUpScenarios.java
@@ -152,7 +152,7 @@ public class MarkUpScenarios {
                 .get("/api/markups/" + documentId)
                 .then()
                 .assertThat()
-                .statusCode(204) //FIXME: it should be 404
+                .statusCode(404)
                 .log().all();
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/em/npa/rest/MarkUpResource.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/npa/rest/MarkUpResource.java
@@ -25,8 +25,8 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 import uk.gov.hmcts.reform.em.npa.config.Constants;
-import uk.gov.hmcts.reform.em.npa.rest.errors.EmptyResponseException;
 import uk.gov.hmcts.reform.em.npa.rest.errors.ValidationErrorException;
 import uk.gov.hmcts.reform.em.npa.rest.util.HeaderUtil;
 import uk.gov.hmcts.reform.em.npa.rest.util.PaginationUtil;
@@ -173,7 +173,9 @@ public class MarkUpResource {
         if (page.hasContent()) {
             return new ResponseEntity<>(page.getContent(), headers, HttpStatus.OK);
         } else {
-            throw new EmptyResponseException("Could not find markups for this document id#" + documentId);
+            throw new ResponseStatusException(
+                    HttpStatus.NOT_FOUND, "Could not find markups for this document id#" + documentId
+            );
         }
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/em/npa/rest/MarkUpResourceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/npa/rest/MarkUpResourceTest.java
@@ -15,8 +15,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.WebDataBinder;
+import org.springframework.web.server.ResponseStatusException;
 import uk.gov.hmcts.reform.em.npa.config.Constants;
-import uk.gov.hmcts.reform.em.npa.rest.errors.EmptyResponseException;
 import uk.gov.hmcts.reform.em.npa.rest.errors.ValidationErrorException;
 import uk.gov.hmcts.reform.em.npa.service.MarkUpService;
 import uk.gov.hmcts.reform.em.npa.service.dto.redaction.RectangleDTO;
@@ -126,7 +126,7 @@ public class MarkUpResourceTest {
         Mockito.verify(markUpService, Mockito.atLeast(1)).findAllByDocumentId(id, pageable);
     }
 
-    @Test(expected = EmptyResponseException.class)
+    @Test(expected = ResponseStatusException.class)
     public void testGetAllDocumentMarkUpsFailure() {
 
         UUID id =  UUID.randomUUID();


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EM-3607


### Change description ###
Update the response code when getting markUp by non-enxistent document ID - returns 204, but should return 404.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
