### PR TITLE
EM-5186 return json response

### DIFF
--- a/src/aat/java/uk/gov/hmcts/reform/em/npa/smoke/SmokeTest.java
+++ b/src/aat/java/uk/gov/hmcts/reform/em/npa/smoke/SmokeTest.java
@@ -13,6 +13,8 @@ import org.springframework.test.context.TestPropertySource;
 import uk.gov.hmcts.reform.em.EmTestConfig;
 import uk.gov.hmcts.reform.em.npa.testutil.TestUtil;
 
+import java.util.Map;
+
 @SpringBootTest(classes = {TestUtil.class, EmTestConfig.class})
 @TestPropertySource(value = "classpath:application.yml")
 @RunWith(SpringIntegrationSerenityRunner.class)
@@ -29,7 +31,7 @@ public class SmokeTest {
 
         SerenityRest.useRelaxedHTTPSValidation();
 
-        String response =
+        Map responseMap =
                 SerenityRest
                         .given()
                         .baseUri(testUrl)
@@ -38,10 +40,10 @@ public class SmokeTest {
                         .statusCode(200)
                         .extract()
                         .body()
-                        .asString();
+                        .as(Map.class);
 
-        Assert.assertEquals(MESSAGE, response);
-
+        Assert.assertEquals(1, responseMap.size());
+        Assert.assertEquals(MESSAGE, responseMap.get("message"));
 
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/em/npa/rest/WelcomeResource.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/npa/rest/WelcomeResource.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Map;
+
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @Slf4j
@@ -29,13 +31,13 @@ public class WelcomeResource {
         produces = APPLICATION_JSON_VALUE
     )
     @ResponseBody
-    public ResponseEntity<String> welcome() {
+    public ResponseEntity<Map<String, String>> welcome() {
 
         log.info("Welcome message : '{}'", MESSAGE);
 
         return ResponseEntity
             .ok()
             .cacheControl(CacheControl.noCache())
-            .body(MESSAGE);
+            .body(Map.of("message",MESSAGE));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/em/npa/rest/WelcomeResourceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/npa/rest/WelcomeResourceTest.java
@@ -4,6 +4,8 @@ import org.junit.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -15,11 +17,11 @@ public class WelcomeResourceTest {
     @Test
     public void test_should_return_welcome_response() {
 
-        ResponseEntity<String> responseEntity = welcomeResource.welcome();
+        ResponseEntity<Map<String, String>> responseEntity = welcomeResource.welcome();
         String expectedMessage = "Welcome to Native PDF Annotator API!";
 
         assertNotNull(responseEntity);
         assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
-        assertThat(responseEntity.getBody()).contains(expectedMessage);
+        assertThat(responseEntity.getBody().get("message")).contains(expectedMessage);
     }
 }


### PR DESCRIPTION
EM-5186 return json response 

`09:56:36  6620 [ZAP-SpiderInitThread-0] INFO  org.zaproxy.zap.spider.Spider - Spider initializing...
09:56:36  6636 [ZAP-SpiderInitThread-0] INFO  org.zaproxy.zap.spider.Spider - Starting spider...
09:56:36  6863 [ZAP-SpiderThreadPool-0-thread-1] ERROR io.swagger.parser.SwaggerCompatConverter - failed to read resource listing
09:56:36  com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'Welcome': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
09:56:36   at [Source: (String)"Welcome to Native PDF Annotator API!"; line: 1, column: 8]
09:56:36  	at com.fasterxml.jackson.core.JsonParser._constructError(JsonParser.java:2337) ~[openapi-beta-28.zap:?]
09:56:36  	at com.fasterxml.jackson.core.base.ParserMinimalBase._reportError(ParserMinimalBase.java:720) ~[openapi-beta-28.zap:?]
09:56:36  	at com.fasterxml.jackson.core.json.ReaderBasedJsonParser._reportInvalidToken(ReaderBasedJsonParser.java:2903) ~[openapi-beta-28.zap:?]
09:56:36  	at com.fasterxml.jackson.core.json.ReaderBasedJsonParser._handleOddValue(ReaderBasedJsonParser.java:1949) ~[openapi-beta-28.zap:?]
09:56:36  	at com.fasterxml.jackson.core.json.ReaderBasedJsonParser.nextToken(ReaderBasedJsonParser.java:781) ~[openapi-beta-28.zap:?]`
