### PR TITLE
Updated redaction logic

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/em/npa/redaction/PdfRedaction.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/npa/redaction/PdfRedaction.java
@@ -77,7 +77,7 @@ public class PdfRedaction {
 
         for (RedactionDTO redactionDTO : redactionDTOList) {
             if (redactionDTO.getRectangles().stream().findFirst().isPresent()) {
-                RectangleDTO rectangle = redactionDTO.getRectangles().stream().findFirst().get();
+                RectangleDTO rectangle = redactionDTO.getRectangles().stream().findFirst().orElse(null);
                 if (Objects.isNull(pages)) {
                     pages = new HashMap<>();
                     createRectangles(pages, redactionDTO);
@@ -97,7 +97,7 @@ public class PdfRedaction {
         if (redactionDTO.getRectangles().stream().findFirst().isPresent()) {
             Set<RectangleDTO> rectangleDtos = new HashSet<>();
             //Currently, from front end we get one rectangle in each Set. Irrespective of the Page.
-            rectangleDtos.add(redactionDTO.getRectangles().stream().findFirst().get());
+            rectangleDtos.add(redactionDTO.getRectangles().stream().findFirst().orElse(null));
             pages.put(redactionDTO.getPage(), rectangleDtos);
         }
     }

--- a/src/main/java/uk/gov/hmcts/reform/em/npa/redaction/PdfRedaction.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/npa/redaction/PdfRedaction.java
@@ -16,7 +16,7 @@ import uk.gov.hmcts.reform.em.npa.service.dto.redaction.RectangleDTO;
 import uk.gov.hmcts.reform.em.npa.service.dto.redaction.RedactionDTO;
 import uk.gov.hmcts.reform.em.npa.service.exception.RedactionProcessingException;
 
-import java.awt.*;
+import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
@@ -63,7 +63,7 @@ public class PdfRedaction {
                                 throw new RedactionProcessingException(ioException.getMessage());
                             }
                         }
-                        );
+                );
             document.save(newFile);
         }
         document.close();

--- a/src/main/java/uk/gov/hmcts/reform/em/npa/redaction/PdfRedaction.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/npa/redaction/PdfRedaction.java
@@ -76,13 +76,14 @@ public class PdfRedaction {
         Map<Integer, Set<RectangleDTO>> pages = null;
 
         for (RedactionDTO redactionDTO : redactionDTOList) {
-            if (!redactionDTO.getRectangles().isEmpty()) {
+            if (redactionDTO.getRectangles().stream().findFirst().isPresent()) {
+                RectangleDTO rectangle = redactionDTO.getRectangles().stream().findFirst().get();
                 if (Objects.isNull(pages)) {
                     pages = new HashMap<>();
                     createRectangles(pages, redactionDTO);
                 } else {
                     if (pages.containsKey(redactionDTO.getPage())) {
-                        pages.get(redactionDTO.getPage()).add(redactionDTO.getRectangles().stream().findFirst().get());
+                        pages.get(redactionDTO.getPage()).add(rectangle);
                     } else {
                         createRectangles(pages, redactionDTO);
                     }
@@ -93,10 +94,12 @@ public class PdfRedaction {
     }
 
     private static void createRectangles(Map<Integer, Set<RectangleDTO>> pages, RedactionDTO redactionDTO) {
-        Set<RectangleDTO> rectangleDtos = new HashSet<>();
-        //Currently, from front end we get one rectangle in each Set. Irrespective of the Page.
-        rectangleDtos.add(redactionDTO.getRectangles().stream().findFirst().get());
-        pages.put(redactionDTO.getPage(), rectangleDtos);
+        if (redactionDTO.getRectangles().stream().findFirst().isPresent()) {
+            Set<RectangleDTO> rectangleDtos = new HashSet<>();
+            //Currently, from front end we get one rectangle in each Set. Irrespective of the Page.
+            rectangleDtos.add(redactionDTO.getRectangles().stream().findFirst().get());
+            pages.put(redactionDTO.getPage(), rectangleDtos);
+        }
     }
 
     /**

--- a/src/main/java/uk/gov/hmcts/reform/em/npa/redaction/PdfRedaction.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/npa/redaction/PdfRedaction.java
@@ -77,17 +77,15 @@ public class PdfRedaction {
         Map<Integer, Set<RectangleDTO>> pages = null;
 
         for (RedactionDTO redactionDTO : redactionDTOList) {
-            if (redactionDTO.getRectangles().stream().findFirst().isPresent()) {
-                RectangleDTO rectangle = redactionDTO.getRectangles().stream().findFirst().orElse(null);
-                if (Objects.isNull(pages)) {
-                    pages = new HashMap<>();
-                    createRectangles(pages, redactionDTO);
+            RectangleDTO rectangle = redactionDTO.getRectangles().stream().findFirst().orElse(null);
+            if (Objects.isNull(pages)) {
+                pages = new HashMap<>();
+                createRectangles(pages, redactionDTO);
+            } else {
+                if (pages.containsKey(redactionDTO.getPage())) {
+                    pages.get(redactionDTO.getPage()).add(rectangle);
                 } else {
-                    if (pages.containsKey(redactionDTO.getPage())) {
-                        pages.get(redactionDTO.getPage()).add(rectangle);
-                    } else {
-                        createRectangles(pages, redactionDTO);
-                    }
+                    createRectangles(pages, redactionDTO);
                 }
             }
         }
@@ -95,12 +93,10 @@ public class PdfRedaction {
     }
 
     private static void createRectangles(Map<Integer, Set<RectangleDTO>> pages, RedactionDTO redactionDTO) {
-        if (redactionDTO.getRectangles().stream().findFirst().isPresent()) {
-            Set<RectangleDTO> rectangleDtos = new HashSet<>();
-            //Currently, from front end we get one rectangle in each Set. Irrespective of the Page.
-            rectangleDtos.add(redactionDTO.getRectangles().stream().findFirst().orElse(null));
-            pages.put(redactionDTO.getPage(), rectangleDtos);
-        }
+        Set<RectangleDTO> rectangleDtos = new HashSet<>();
+        //Currently, from front end we get one rectangle in each Set. Irrespective of the Page.
+        rectangleDtos.add(redactionDTO.getRectangles().stream().findFirst().orElse(null));
+        pages.put(redactionDTO.getPage(), rectangleDtos);
     }
 
     /**


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EM-5479
### Change description ###
Updated redaction logic. So now, instead of doing below for each of the redaction,

1. redactPageContent
2. transformToImage
3. transformToPdf
4. replacePage
We now are doing above per page. So if there 2 redactions on a page. Instead of looping twice through, we will now loop only once. So that better than previous approach.
**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```
