### PR TITLE
EM-6254 avoid using connection key

### DIFF
--- a/src/cftlib/resources/docker-compose-local.yml
+++ b/src/cftlib/resources/docker-compose-local.yml
@@ -14,7 +14,7 @@ services:
       SPRING_DATASOURCE_PASSWORD: "postgres"
       ENABLE_AZURE_STORAGE_CONTAINER: "true"
       ENABLE_POSTGRES_BLOB_STORAGE: "false"
-      STORAGEACCOUNT_PRIMARY_CONNECTION_STRING: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azure-storage-emulator-azurite:10000/devstoreaccount1"
+      STORAGEACCOUNT_PRIMARY_CONNECTION_STRING: "UseDevelopmentStorage=true"
       STORAGE_CONTAINER_DOCUMENT_CONTAINER_NAME: "hmctstestcontainer"
       SPRING_PROFILES_ACTIVE: dev
       IDAM_TESTING_SUPPORT_ENABLED: "true"


### PR DESCRIPTION
### Jira link
EM-6254 avoid using connection key

 avoid using connection  key, Fortify thinks they are real and Fortify team reject to suppress them.

<img width="1075" alt="Screenshot 2024-09-20 at 08 28 31" src="https://github.com/user-attachments/assets/e3aa5475-0899-4e4c-b18e-e313f31436ad">


instead of long connection key 
"DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"

https://github.com/Azure/Azurite
use short connection string:

"UseDevelopmentStorage=true"