### PR TITLE
EM-7158 uk.gov.hmcts.java to v0.12.70 and fix CVE 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
     id 'application'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'org.springframework.boot' version '3.5.14'
-    id 'uk.gov.hmcts.java' version '0.12.68'
+    id 'uk.gov.hmcts.java' version '0.12.70'
     id 'com.github.ben-manes.versions' version '0.54.0'
     id 'org.sonarqube' version '7.3.0.8198'
     id 'jacoco'
@@ -253,18 +253,21 @@ dependencies {
 
 dependencyManagement {
     dependencies {
-        //CVE-2022-23437
-        dependencySet(group: 'xerces', version: '2.12.2') {
-            entry 'xercesImpl'
-        }
-        //CVE-2020-13956
-        dependencySet(group: 'org.apache.httpcomponents', version: '4.5.14') {
-            entry 'fluent-hc'
-        }
         dependencySet(group: 'org.junit.platform', version: '6.0.3') {
             entry 'junit-platform-commons'
             entry 'junit-platform-engine'
             entry 'junit-platform-launcher'
+        }
+        //CVE-2026-41284, CVE-2026-42498, CVE-2026-43514, CVE-2026-41293, CVE-2026-43512, CVE-2026-43513, CVE-2026-43515
+        dependencySet(group: 'org.apache.tomcat.embed', version: '10.1.55') {
+            entry 'tomcat-embed-core'
+            entry 'tomcat-embed-el'
+            entry 'tomcat-embed-websocket'
+        }
+        //CVE-2026-34477, CVE-2026-34479
+        dependencySet(group: 'org.apache.logging.log4j', version: versions.log4JVersion) {
+            entry 'log4j-api'
+            entry 'log4j-to-slf4j'
         }
     }
 }

--- a/config/owasp/dependency-check-suppressions.xml
+++ b/config/owasp/dependency-check-suppressions.xml
@@ -1,3 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+
+    <suppress until="2026-08-18Z">
+        <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin-stdlib@.*$</packageUrl>
+        <cve>CVE-2020-29582</cve>
+    </suppress>
+
 </suppressions>

--- a/config/owasp/dependency-check-suppressions.xml
+++ b/config/owasp/dependency-check-suppressions.xml
@@ -5,5 +5,32 @@
         <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin-stdlib@.*$</packageUrl>
         <cve>CVE-2020-29582</cve>
     </suppress>
+    <suppress until="2027-05-18Z">
+        <packageUrl regex="true">^pkg:maven/org\.eclipse\.angus/angus-activation@.*$</packageUrl>
+        <cve>CVE-2025-7962</cve>
+    </suppress>
+    <suppress until="2027-05-18Z">
+        <packageUrl regex="true">^pkg:maven/com\.itextpdf/cleanup@.*$</packageUrl>
+        <cve>CVE-2017-9096</cve>
+    </suppress>
+    <suppress until="2027-05-18Z">
+        <packageUrl regex="true">^pkg:maven/com\.itextpdf/cleanup@.*$</packageUrl>
+        <cve>CVE-2022-24196</cve>
+    </suppress>
+    <suppress until="2027-05-18Z">
+        <packageUrl regex="true">^pkg:maven/com\.itextpdf/cleanup@.*$</packageUrl>
+        <cve>CVE-2022-24197</cve>
+    </suppress>
+
+    <!-- CVE-2026-23907, CVE-2026-33929: Affect pdfbox-examples (ExtractEmbeddedFiles example only), not the core
+         pdfbox/pdfbox-io/jbig2-imageio libraries. Fix in pdfbox 3.0.8 not yet released. -->
+    <suppress until="2027-05-18Z">
+        <packageUrl regex="true">^pkg:maven/org\.apache\.pdfbox/(pdfbox|pdfbox-io|jbig2-imageio)@.*$</packageUrl>
+        <cve>CVE-2026-23907</cve>
+    </suppress>
+    <suppress until="2027-05-18Z">
+        <packageUrl regex="true">^pkg:maven/org\.apache\.pdfbox/(pdfbox|pdfbox-io|jbig2-imageio)@.*$</packageUrl>
+        <cve>CVE-2026-33929</cve>
+    </suppress>
 
 </suppressions>


### PR DESCRIPTION
[EM-7158](https://tools.hmcts.net/jira/browse/EM-7158) uk.gov.hmcts.java to v0.12.70 and fix CVE 