### PR TITLE
EM-7210 remove spring lib version setting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -251,10 +251,6 @@ dependencies {
     cftlibImplementation 'org.springframework.boot:spring-boot-devtools'
 }
 
-
-//CVE-2026-41840, CVE-2026-41841, CVE-2026-41842, CVE-2026-41843, CVE-2026-41850, CVE-2026-41851
-ext['spring-framework.version'] = '6.2.19'
-
 dependencyManagement {
     dependencies {
         dependency 'org.jetbrains.kotlin:kotlin-stdlib:2.4.0'


### PR DESCRIPTION

### Jira link

[EM-7210](https://tools.hmcts.net/jira/browse/EM-7210)
Removed commented CVE references and spring-framework version setting.
